### PR TITLE
Added method to convert attribute keys to lowercase

### DIFF
--- a/welleng/exchange/edm.py
+++ b/welleng/exchange/edm.py
@@ -40,6 +40,8 @@ class EDM:
                 raise ValueError(f"Error loading the EDM file. Error code: {response.status_code}")
         else:
             raise AttributeError(f'Invalid source {source}. Source must be "file" or "link"')
+
+        self.convert_attribute_lowercase()
         self._wellbore_id_to_name()
         self._wellbore_id_to_well_id()
 
@@ -129,6 +131,12 @@ class EDM:
         for _, v in self.get_wellbore_ids().items():
             self.wellbore_id_to_name[v['wellbore_id']] = v['wellbore_name']
             self.wellbore_name_to_id[v['wellbore_name']] = v['wellbore_id']
+
+    def convert_attribute_lowercase(self):
+        for tag in self.get_tags():
+            for child in self.root:
+                if child.tag == tag:
+                    child.attrib = {k.lower(): v for k, v in child.attrib.items()}
 
     def get_wells(self):
         return {


### PR DESCRIPTION
The ISCWSA example file has all attribute keys in uppercase. This creates issues in parsing as the existing code expects keys in lowercase. Added a method to convert all keys to all attributes in the EDM file to lowercase. 